### PR TITLE
Fix broken syntax highlighting in JSON files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.json linguist-language=javascript


### PR DESCRIPTION
Files inside `data/` are in non-strict format which is actually invalid JSON.
This change tells Github to use JavaScript grammar instead.